### PR TITLE
Also close the @reader on #fill

### DIFF
--- a/lib/pdf/stamper.rb
+++ b/lib/pdf/stamper.rb
@@ -40,9 +40,9 @@ module PDF
     end
   
     def template(template)
-      reader = PdfReader.new(template)
+      @reader = PdfReader.new(template)
       @baos = ByteArrayOutputStream.new
-      @stamp = PdfStamper.new(reader, @baos)
+      @stamp = PdfStamper.new(@reader, @baos)
       @form = @stamp.getAcroFields()
       @canvas = @stamp.getOverContent(1)
     end
@@ -214,6 +214,7 @@ module PDF
       @canvas.stroke()
       @stamp.setFormFlattening(true)
       @stamp.close
+      @reader.close
     end
   end
 end


### PR DESCRIPTION
With the updated iText library (5.0), the reader variable is not closed and it is never garbage collected, leading to an open file leak that'll eventually exhaust system file handlers.